### PR TITLE
Implement User Account Deletion Endpoint

### DIFF
--- a/app/Http/Controllers/API/UserController.php
+++ b/app/Http/Controllers/API/UserController.php
@@ -106,4 +106,24 @@ class UserController extends Controller
         
         return new UserResource($user);
     }
+
+    /**
+     * Delete user account.
+     *
+     * @param  Request $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function destroy(Request $request)
+    {
+        $user = $request->user();
+        
+        // Revoke all tokens
+        $user->tokens()->delete();
+        
+        // Delete the user
+        $user->delete();
+        
+        return response()->json(null, 204);
+    }
+    
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,6 +11,7 @@ Route::middleware('auth:api')->group(function () {
     Route::delete('/tokens', [AuthController::class, 'logout'])->name('tokens.destroy');
     Route::get('/users/{id?}', [UserController::class, 'show'])->name('users.show');
     Route::put('/users/{id?}', [UserController::class, 'update'])->name('users.update');
+    Route::delete('/users', [UserController::class, 'destroy'])->name('users.destroy');
 });
 
 Route::get('/test', function () {

--- a/tests/Feature/API/User/DeleteUserProfileTest.php
+++ b/tests/Feature/API/User/DeleteUserProfileTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature\API\User;
+
+use Tests\Feature\API\ApiTestCase;
+
+class DeleteUserProfileTest extends ApiTestCase
+{
+    /**
+     * Test an authenticated user can delete their account
+     */
+    public function test_authenticated_user_can_delete_account(): void
+    {
+        $this->createAuthenticatedUser();
+        $userId = $this->user->id;
+        
+        $response = $this->deleteJson('/api/users', [], $this->authHeaders());
+
+        $response->assertStatus(204);
+        
+        // Verify user was deleted
+        $this->assertDatabaseMissing('users', [
+            'id' => $userId,
+        ]);
+    }
+
+    /**
+     * Test all tokens are revoked when user deletes account
+     */
+    public function test_all_tokens_are_revoked_when_account_is_deleted(): void
+    {
+        $this->createAuthenticatedUser();
+        $userId = $this->user->id;
+        
+        // Create multiple tokens for user
+        $this->user->createToken('test_token_1')->accessToken;
+        $this->user->createToken('test_token_2')->accessToken;
+        
+        // Verify tokens exist
+        $this->assertDatabaseHas('oauth_access_tokens', [
+            'user_id' => $userId,
+            'revoked' => 0
+        ]);
+        
+        // Delete account
+        $response = $this->deleteJson('/api/users', [], $this->authHeaders());
+        $response->assertStatus(204);
+        
+        // Verify all tokens were revoked or deleted
+        $this->assertDatabaseMissing('oauth_access_tokens', [
+            'user_id' => $userId,
+            'revoked' => 0
+        ]);
+    }
+
+    /**
+     * Test unauthenticated user cannot delete account
+     */
+    public function test_unauthenticated_user_cannot_delete_account(): void
+    {
+        $response = $this->deleteJson('/api/users');
+        
+        $response->assertStatus(401);
+    }
+}


### PR DESCRIPTION
This PR implements the user account deletion endpoint for our Laravel API REST application following TDD principles.

##Key changes:
- Create DeleteUserProfileTest with test cases for account deletion
- Implement token revocation logic to ensure all user tokens are invalidated
- Add destroy method to UserController to handle account removal process
- Configure proper response codes (204 No Content) for successful deletion
- Set up protected DELETE /api/users endpoint
- Verify database consistency after deletion operations
- Ensure proper authentication checks prevent unauthorized account deletion