### PR TITLE
Implement user deck endpoint

### DIFF
--- a/app/Http/Controllers/API/DeckController.php
+++ b/app/Http/Controllers/API/DeckController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Services\DeckService;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+
+class DeckController extends Controller
+{
+    protected $deckService;
+
+    public function __construct(DeckService $deckService)
+    {
+        $this->deckService = $deckService;
+    }
+
+    /**
+     * Get the authenticated user's deck.
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function index(Request $request): JsonResponse
+    {
+        // Verificar autenticación explícitamente
+        $user = $request->user();
+        if (!$user) {
+            return response()->json(['error' => 'Unauthorized'], 401);
+        }
+        
+        $deck = $this->deckService->getUserDeck($user);
+        $deckCards = $this->deckService->getDeckCards($deck);
+        
+        // Load the card relationship on each deck card for the response
+        $deckCards->load('card');
+        
+        return response()->json([
+            'data' => [
+                'id' => $deck->id,
+                'user_id' => $deck->user_id,
+                'last_used' => $deck->last_used,
+                'cards' => $deckCards->map(function($deckCard) {
+                    return [
+                        'id' => $deckCard->id,
+                        'position' => $deckCard->position,
+                        'card' => $deckCard->card
+                    ];
+                })
+            ]
+        ]);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -14,6 +14,8 @@ class User extends Authenticatable
     /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasApiTokens, HasFactory, Notifiable, HasRoles;
 
+    protected $guard_name = 'api';
+
     /**
      * The attributes that are mass assignable.
      *

--- a/app/Services/DeckService.php
+++ b/app/Services/DeckService.php
@@ -6,8 +6,6 @@ use App\Models\Card;
 use App\Models\Deck;
 use App\Models\User;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
-use Exception;
 
 class DeckService
 {

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -13,7 +13,7 @@ class RoleSeeder extends Seeder
      */
     public function run(): void
     {
-        Role::create(['name' => 'admin']);
-        Role::create(['name' => 'user']);
+        Role::create(['name' => 'admin', 'guard_name' => 'api']);
+        Role::create(['name' => 'user', 'guard_name' => 'api']);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\API\UserController;
 use App\Http\Controllers\API\AuthController;
+use App\Http\Controllers\API\DeckController;
 
 Route::post('/users', [UserController::class, 'store'])->name('users.store');
 Route::post('/tokens', [AuthController::class, 'login'])->name('tokens.create');
@@ -12,6 +13,7 @@ Route::middleware('auth:api')->group(function () {
     Route::get('/users/{id?}', [UserController::class, 'show'])->name('users.show');
     Route::put('/users/{id?}', [UserController::class, 'update'])->name('users.update');
     Route::delete('/users', [UserController::class, 'destroy'])->name('users.destroy');
+    Route::get('/decks', [DeckController::class, 'index'])->name('decks.index');
 });
 
 Route::get('/test', function () {

--- a/tests/Feature/Deck/GetUserDeckTest.php
+++ b/tests/Feature/Deck/GetUserDeckTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Feature\Deck;
+
+use App\Models\User;
+use App\Models\Deck;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use Tests\TestCase;
+
+class GetUserDeckTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Set up the test environment.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed('TarotCardsSeeder');
+    }
+
+    /**
+     * Test that an authenticated user can get their deck.
+     *
+     * @return void
+     */
+    public function test_user_can_get_their_deck(): void
+    {
+        // Arrange: Setup a user with a deck
+        $user = User::factory()->create();
+        
+        // User should have a deck created via the observer
+        $deck = Deck::where('user_id', $user->id)->first();
+        $this->assertNotNull($deck);
+        
+        // Act: Authenticate as user and make request
+        Passport::actingAs($user);
+        $response = $this->getJson('/api/decks');
+        
+        // Assert: Verify the response
+        $response->assertStatus(200)
+                 ->assertJsonStructure([
+                     'data' => [
+                         'id',
+                         'user_id',
+                         'last_used',
+                         'cards' => [
+                             '*' => [
+                                 'id',
+                                 'position',
+                                 'card' => [
+                                     'id',
+                                     'type',
+                                     'number',
+                                     'name',
+                                     'suit',
+                                     'element',
+                                     'meaning'
+                                 ]
+                             ]
+                         ]
+                     ]
+                 ]);
+        
+        // Verify that the returned deck belongs to the user
+        $this->assertEquals($user->id, $response->json('data.user_id'));
+        
+        // Verify that we have all 78 cards
+        $this->assertCount(78, $response->json('data.cards'));
+    }
+
+    /**
+     * Test that unauthenticated users cannot access the deck.
+     *
+     * @return void
+     */
+    public function test_unauthenticated_user_cannot_get_deck(): void
+    {
+        // Act: Make request without authentication
+        $response = $this->getJson('/api/decks');
+        
+        // Assert: Verify the response is unauthorized
+        $response->assertStatus(401);
+    }
+
+    /**
+     * Test that a user can only see their own deck.
+     *
+     * @return void
+     */
+    public function test_user_can_only_see_own_deck(): void
+    {
+        // Arrange: Setup two users with decks
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+        
+        // Both users should have decks created via observer
+        $deck1 = Deck::where('user_id', $user1->id)->first();
+        $deck2 = Deck::where('user_id', $user2->id)->first();
+        
+        $this->assertNotNull($deck1);
+        $this->assertNotNull($deck2);
+        
+        // Act: Authenticate as user1 and get deck
+        Passport::actingAs($user1);
+        $response = $this->getJson('/api/decks');
+        
+        // Assert: Verify that user1 can only see their own deck
+        $response->assertStatus(200);
+        $this->assertEquals($user1->id, $response->json('data.user_id'));
+        $this->assertEquals($deck1->id, $response->json('data.id'));
+        $this->assertNotEquals($deck2->id, $response->json('data.id'));
+    }
+
+}

--- a/tests/Unit/DeckTest.php
+++ b/tests/Unit/DeckTest.php
@@ -14,13 +14,19 @@ class DeckTest extends TestCase
     use RefreshDatabase;
 
     /**
+     * Set up the test environment.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed('TarotCardsSeeder');
+    }
+
+    /**
      * Test that a deck is automatically created for a new user.
      */
     public function test_deck_is_created_when_user_registers(): void
-    {
-        // Arrange: We need cards in the database
-        $this->seed('TarotCardsSeeder');
-        
+    {   
         // Act: Create a new user, which should trigger deck creation
         $user = User::factory()->create();
 
@@ -43,9 +49,6 @@ class DeckTest extends TestCase
      */
     public function test_deck_card_relationships(): void
     {
-        // Arrange: We need cards in the database
-        $this->seed('TarotCardsSeeder');
-        
         // Create a user and get their deck
         $user = User::factory()->create();
         $deck = Deck::where('user_id', $user->id)->first();


### PR DESCRIPTION
This PR implements the user deck retrieval endpoint following TDD principles.

Key changes:

- Create tests to verify authenticated access to user's deck
- Implement authentication checks to prevent unauthorized access
- Set up protected GET /api/decks endpoint
- Add proper JSON formatting for deck and card information
- Optimize test performance with improved seeding approach
- Ensure clear separation between user decks (a user can only access their own deck)

All tests pass successfully, and the endpoint can be tested with Postman using the authentication flow.