### PR TITLE
Implement spread creation endpoint

### DIFF
--- a/app/Http/Controllers/API/DeckController.php
+++ b/app/Http/Controllers/API/DeckController.php
@@ -4,8 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Services\DeckService;
-use Illuminate\Http\Request;
-use Illuminate\Http\JsonResponse;
+use Illuminate\Http\{Request, JsonResponse};
 
 class DeckController extends Controller
 {

--- a/app/Http/Controllers/API/SpreadController.php
+++ b/app/Http/Controllers/API/SpreadController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Models\Spread;
+use App\Services\{DeckService, SpreadService};
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class SpreadController extends Controller
+{
+    protected $spreadService;
+    protected $deckService;
+    
+    public function __construct(SpreadService $spreadService, DeckService $deckService)
+    {
+        $this->spreadService = $spreadService;
+        $this->deckService = $deckService;
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'spread_type' => 'required|in:' . implode(',', Spread::TYPES),
+        ]);
+        
+        try {
+            $spreadData = $this->spreadService->createSpread($validated['spread_type']);
+            
+            Log::info('Spread created with ID: ' . $spreadData['id']);
+            
+            return response()->json($spreadData, 201);
+                
+        } catch (\Exception $e) {
+            Log::error('Error creating spread: ' . $e->getMessage());
+            
+            return response()->json([
+                'message' => 'Failed to create spread',
+                'error' => $e->getMessage()
+            ], 500);
+        }
+    }
+}

--- a/app/Models/Deck.php
+++ b/app/Models/Deck.php
@@ -11,46 +11,32 @@ class Deck extends Model
 {
     use HasFactory;
 
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array<int, string>
-     */
     protected $fillable = [
         'user_id',
         'last_used',
     ];
 
-    /**
-     * The attributes that should be cast.
-     *
-     * @var array<string, string>
-     */
     protected $casts = [
         'last_used' => 'datetime',
     ];
 
-    /**
-     * Update the last used timestamp.
-     */
     public function updateLastUsed(): void
     {
         $this->update(['last_used' => now()]);
     }
 
-    /**
-     * Get the user that owns the deck.
-     */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
     }
 
-    /**
-     * Get the deck cards in this deck.
-     */
     public function cards(): HasMany
     {
         return $this->hasMany(DeckCard::class);
     }
+
+    public function spreads(): HasMany
+    {
+        return $this->hasMany(Spread::class);
+    }   
 }

--- a/app/Models/Spread.php
+++ b/app/Models/Spread.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\{HasMany, BelongsTo};
+
+class Spread extends Model
+{
+    use HasFactory;
+
+    public const TYPE_SINGLE = 'first';
+    public const TYPE_THREE = 'second';
+
+    public const TYPES = [
+        self::TYPE_SINGLE,
+        self::TYPE_THREE
+    ];
+
+    protected $fillable = [
+        'deck_id',
+        'spread_type',
+        'creation_date'
+    ];
+
+    protected $casts = [
+        'creation_date' => 'datetime',
+    ];
+
+    public function deck(): BelongsTo
+    {
+        return $this->belongsTo(Deck::class);
+    }
+
+    public function spreadCards(): HasMany
+    {
+        return $this->hasMany(SpreadCard::class);
+    }
+
+    public function toArray()
+    {
+        return [
+            'id' => $this->id,
+            'deck_id' => $this->deck_id,
+            'spread_type' => $this->spread_type,
+            'creation_date' => $this->creation_date->format('Y-m-d H:i:s'),
+            'card_count' => $this->spreadCards()->count()
+        ];
+    }
+}

--- a/app/Models/SpreadCard.php
+++ b/app/Models/SpreadCard.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class SpreadCard extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'spread_id',
+        'card_id',
+        'position'
+    ];
+
+    public function spread(): BelongsTo
+    {
+        return $this->belongsTo(Spread::class);
+    }
+
+    public function card(): BelongsTo
+    {
+        return $this->belongsTo(Card::class);
+    }
+    
+    public function toArray()
+    {
+        return [
+            'id' => $this->id,
+            'position' => $this->position,
+            'card' => $this->card->toArray()
+        ];
+    }
+}

--- a/app/Services/SpreadService.php
+++ b/app/Services/SpreadService.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+use App\Models\Spread;
+use App\Models\SpreadCard;
+use Illuminate\Database\Eloquent\Collection;
+
+class SpreadService
+{
+    protected $deckService;
+
+    public function __construct(DeckService $deckService)
+    {
+        $this->deckService = $deckService;
+    }
+
+    public function createSpread(string $spreadType): array
+    {
+        return match($spreadType) {
+            Spread::TYPE_SINGLE => $this->createSingleCardSpread($spreadType),
+            Spread::TYPE_THREE => $this->createThreeCardSpread($spreadType),
+        };
+    }
+
+    public function createSingleCardSpread(string $spreadType = null): array
+    {
+        return $this->createSpreadWithCardCount(
+            $spreadType ?? Spread::TYPE_SINGLE, 
+            1, 
+            [2]
+        );
+    }
+
+    public function createThreeCardSpread(string $spreadType = null): array
+    {
+        return $this->createSpreadWithCardCount(
+            $spreadType ?? Spread::TYPE_THREE, 
+            3, 
+            [2, 1, 3]
+        );
+    }
+
+    private function createSpreadWithCardCount(string $spreadType, int $cardCount, array $positions): array
+    {
+        return $this->executeInTransaction(function() use ($spreadType, $cardCount, $positions) {
+            $deck = $this->deckService->getCurrentUserDeck();
+            $deck->updateLastUsed();
+            
+            $selectedCards = $this->selectRandomCardsFromDeck($deck, $cardCount);
+            $spread = $this->createBaseSpread($deck->id, $spreadType);
+            $spreadCards = $this->createSpreadCards($spread, $selectedCards, $positions);
+            
+            return $this->formatSpreadResponse(
+                $spread, 
+                collect($spreadCards)->map->toArray()->toArray()
+            );
+        });
+    }
+
+    public function getSpread(int $spreadId): array
+    {
+        $spread = Spread::with('spreadCards.card')->findOrFail($spreadId);
+        
+        $cardsData = $spread->spreadCards->sortBy('position')->values()->map->toArray()->toArray();
+        
+        return $this->formatSpreadResponse($spread, $cardsData);
+    }
+    
+    public function getSpreadsForDeck(): array
+    {
+        $deck = $this->deckService->getCurrentUserDeck();
+        $query = Spread::where('deck_id', $deck->id);
+        
+        $spreads = $query->orderBy('creation_date', 'desc')->get();
+        
+        return [
+            'deck_id' => $deck->id,
+            'spreads' => $spreads->map(fn($spread) => $spread->toArray())->toArray()
+        ];
+    }
+    
+    private function executeInTransaction(callable $callback)
+    {
+        DB::beginTransaction();
+        
+        try {
+            $result = $callback();
+            DB::commit();
+            return $result;
+        } catch (\Exception $e) {
+            DB::rollBack();
+            throw $e;
+        }
+    }
+
+    private function createSpreadCards(Spread $spread, Collection $deckCards, array $positions): array
+    {
+        $spreadCards = [];
+        
+        foreach ($deckCards as $index => $deckCard) {
+            $position = $positions[$index] ?? ($index + 1);
+            
+            $spreadCard = SpreadCard::create([
+                'spread_id' => $spread->id,
+                'card_id' => $deckCard->card_id,
+                'position' => $position
+            ]);
+            
+            $spreadCard->setRelation('card', $deckCard->card);
+            $spreadCards[] = $spreadCard;
+        }
+        
+        return $spreadCards;
+    }
+    
+    private function selectRandomCardsFromDeck($deck, int $count): Collection
+    {
+        return $deck->cards()->with('card')->get()->random($count);
+    }
+
+    private function createBaseSpread(int $deckId, string $spreadType): Spread
+    {
+        return Spread::create([
+            'deck_id' => $deckId,
+            'spread_type' => $spreadType,
+            'creation_date' => now()
+        ]);
+    }
+    
+    private function formatSpreadResponse(Spread $spread, array $cards): array
+    {
+        return [
+            'id' => $spread->id,
+            'deck_id' => $spread->deck_id,
+            'spread_type' => $spread->spread_type,
+            'creation_date' => $spread->creation_date->format('Y-m-d H:i:s'),
+            'cards' => $cards
+        ];
+    }
+}

--- a/database/migrations/2025_04_18_105806_create_decks_table.php
+++ b/database/migrations/2025_04_18_105806_create_decks_table.php
@@ -16,8 +16,7 @@ return new class extends Migration
             $table->foreignId('user_id')->constrained()->onDelete('cascade');
             $table->timestamp('last_used')->nullable();
             $table->timestamps();
-            
-            // Cada usuario solo puede tener un mazo
+
             $table->unique('user_id');
         });
     }

--- a/database/migrations/2025_04_23_103155_create_spreads_table.php
+++ b/database/migrations/2025_04_23_103155_create_spreads_table.php
@@ -6,29 +6,22 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
-        Schema::create('deck_cards', function (Blueprint $table) {
+        Schema::create('spreads', function (Blueprint $table) {
             $table->id();
             $table->foreignId('deck_id')->constrained()->onDelete('cascade');
-            $table->foreignId('card_id')->constrained()->onDelete('cascade');
-            $table->integer('position');
+            $table->enum('spread_type', ['first', 'second'])->default('first');
+            $table->timestamp('creation_date')->useCurrent();
             $table->timestamps();
             
-            $table->unique(['deck_id', 'card_id']);
-            
-            $table->index('position');
+            $table->index('deck_id');
+            $table->index('spread_type');
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
-        Schema::dropIfExists('deck_cards');
+        Schema::dropIfExists('spreads');
     }
 };

--- a/database/migrations/2025_04_23_103257_create_spread_cards_table.php
+++ b/database/migrations/2025_04_23_103257_create_spread_cards_table.php
@@ -6,29 +6,22 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
-        Schema::create('deck_cards', function (Blueprint $table) {
+        Schema::create('spread_cards', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('deck_id')->constrained()->onDelete('cascade');
+            $table->foreignId('spread_id')->constrained()->onDelete('cascade');
             $table->foreignId('card_id')->constrained()->onDelete('cascade');
             $table->integer('position');
             $table->timestamps();
             
-            $table->unique(['deck_id', 'card_id']);
-            
+            $table->index('spread_id');
             $table->index('position');
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
-        Schema::dropIfExists('deck_cards');
+        Schema::dropIfExists('spread_cards');
     }
 };

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,9 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\API\UserController;
-use App\Http\Controllers\API\AuthController;
-use App\Http\Controllers\API\DeckController;
+use App\Http\Controllers\API\{UserController, AuthController, DeckController, SpreadController};
 
 Route::post('/users', [UserController::class, 'store'])->name('users.store');
 Route::post('/tokens', [AuthController::class, 'login'])->name('tokens.create');
@@ -15,6 +13,7 @@ Route::middleware('auth:api')->group(function () {
     Route::delete('/users', [UserController::class, 'destroy'])->name('users.destroy');
     Route::get('/decks', [DeckController::class, 'index'])->name('decks.index');
     Route::put('/decks', [DeckController::class, 'update']);
+    Route::post('/spreads', [SpreadController::class, 'store']);
 });
 
 Route::get('/test', function () {

--- a/tests/Feature/API/Deck/DeckActionsTest.php
+++ b/tests/Feature/API/Deck/DeckActionsTest.php
@@ -5,10 +5,9 @@ namespace Tests\Feature\API\Deck;
 use App\Models\User;
 use App\Models\Deck;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Laravel\Passport\Passport;
-use Tests\TestCase;
+use Tests\Feature\API\ApiTestCase;
 
-class DeckActionsTest extends TestCase
+class DeckActionsTest extends ApiTestCase
 {
     use RefreshDatabase;
 
@@ -19,15 +18,28 @@ class DeckActionsTest extends TestCase
     {
         parent::setUp();
         
-        // Solo sembramos las cartas
         $this->seed('TarotCardsSeeder');
-        
-        // Crear un usuario para las pruebas (el deck se creará automáticamente por el observer)
-        $this->user = User::factory()->create();
-        
-        // Obtener el mazo que se creó automáticamente
+        $this->createAuthenticatedUser();
         $this->deck = Deck::where('user_id', $this->user->id)->first();
-        $this->assertNotNull($this->deck, "No se creó automáticamente un mazo para el usuario");
+        $this->assertNotNull($this->deck, "Deck was not created");
+    }
+
+    public function test_action_type_is_required(): void
+    {        
+        $response = $this->putJson('/api/decks', [], $this->authHeaders());
+        
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['action_type']);
+    }
+
+    public function test_invalid_action_type_returns_error(): void
+    {        
+        $response = $this->putJson('/api/decks', [
+            'action_type' => 'invalid_action'
+        ], $this->authHeaders());
+        
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['action_type']);
     }
 
     public function test_unauthenticated_user_cannot_shuffle_deck(): void
@@ -41,19 +53,14 @@ class DeckActionsTest extends TestCase
     
     public function test_authenticated_user_can_shuffle_deck(): void
     {
-        // Guardar el orden original de las cartas
         $originalOrder = $this->deck->cards()
             ->orderBy('position', 'asc')
             ->pluck('position', 'card_id')
             ->toArray();
-        
-        // Autenticar al usuario
-        Passport::actingAs($this->user);
-        
-        // Realizar la acción de barajar
+                
         $response = $this->putJson('/api/decks', [
             'action_type' => 'shuffle'
-        ]);
+        ], $this->authHeaders());
         
         $response->assertStatus(200)
             ->assertJsonStructure([
@@ -70,17 +77,14 @@ class DeckActionsTest extends TestCase
                 ]
             ]);
         
-        // Verificar que el orden de las cartas ha cambiado en la base de datos
         $this->deck->refresh();
         $newDbOrder = $this->deck->cards()
             ->orderBy('position', 'asc')
             ->pluck('position', 'card_id')
             ->toArray();
         
-        // Asegurar que el nuevo orden en la DB es diferente al original
         $this->assertNotEquals($originalOrder, $newDbOrder);
         
-        // Verificar que el orden en la respuesta coincide con el guardado en la DB
         $responseCards = collect($response->json('data.cards'))->keyBy('card_id');
         $dbCards = $this->deck->cards()->get()->keyBy('card_id');
         
@@ -88,39 +92,21 @@ class DeckActionsTest extends TestCase
             $this->assertEquals(
                 $dbCard->position, 
                 $responseCards[$cardId]['position'], 
-                "La posición de la carta {$cardId} en la base de datos no coincide con la respuesta"
+                "The position of card {$cardId} in the database does not match the response"
             );
         }
     }
     
-    public function test_invalid_action_type_returns_error(): void
-    {
-        // Autenticar al usuario
-        Passport::actingAs($this->user);
-        
-        $response = $this->putJson('/api/decks', [
-            'action_type' => 'invalid_action'
-        ]);
-        
-        $response->assertStatus(422)
-            ->assertJsonValidationErrors(['action_type']);
-    }
-    
     public function test_authenticated_user_can_cut_deck(): void
     {
-        // Guardar el orden original de las cartas
         $originalOrder = $this->deck->cards()
             ->orderBy('position', 'asc')
             ->pluck('position', 'card_id')
             ->toArray();
-        
-        // Autenticar al usuario
-        Passport::actingAs($this->user);
-        
-        // Realizar la acción de cortar
+                
         $response = $this->putJson('/api/decks', [
             'action_type' => 'cut'
-        ]);
+        ], $this->authHeaders());
         
         $response->assertStatus(200)
             ->assertJsonStructure([
@@ -141,17 +127,14 @@ class DeckActionsTest extends TestCase
                 ]
             ]);
         
-        // Verificar que el orden de las cartas ha cambiado en la base de datos
         $this->deck->refresh();
         $newDbOrder = $this->deck->cards()
             ->orderBy('position', 'asc')
             ->pluck('position', 'card_id')
             ->toArray();
         
-        // Asegurar que el nuevo orden en la DB es diferente al original
         $this->assertNotEquals($originalOrder, $newDbOrder);
         
-        // Verificar que el orden en la respuesta coincide con el guardado en la DB
         $responseCards = collect($response->json('data.cards'))->keyBy('card_id');
         $dbCards = $this->deck->cards()->get()->keyBy('card_id');
         
@@ -159,31 +142,18 @@ class DeckActionsTest extends TestCase
             $this->assertEquals(
                 $dbCard->position, 
                 $responseCards[$cardId]['position'], 
-                "La posición de la carta {$cardId} en la base de datos no coincide con la respuesta"
+                "The position of card {$cardId} in the database does not match the response"
             );
         }
         
-        // Verificar que todas las cartas están presentes después del corte
         $this->assertCount(count($originalOrder), $newDbOrder);
         
-        // Verificar que la operación de corte se ha realizado correctamente
         $cutInfo = $response->json('data.cut_info');
         
-        // Verificar que la suma de ambas mitades es igual al total de cartas
         $this->assertEquals(
             count($originalOrder), 
             count($cutInfo['first_half']) + count($cutInfo['second_half'])
         );
     }
-    
-    public function test_action_type_is_required(): void
-    {
-        // Autenticar al usuario
-        Passport::actingAs($this->user);
-        
-        $response = $this->putJson('/api/decks', []);
-        
-        $response->assertStatus(422)
-            ->assertJsonValidationErrors(['action_type']);
-    }
+
 }

--- a/tests/Feature/API/Deck/GetUserDeckTest.php
+++ b/tests/Feature/API/Deck/GetUserDeckTest.php
@@ -5,41 +5,30 @@ namespace Tests\Feature\Deck;
 use App\Models\User;
 use App\Models\Deck;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Laravel\Passport\Passport;
-use Tests\TestCase;
+use Tests\Feature\API\ApiTestCase;
 
-class GetUserDeckTest extends TestCase
+class GetUserDeckTest extends ApiTestCase
 {
     use RefreshDatabase;
 
-    /**
-     * Set up the test environment.
-     */
+    protected User $user;
+    protected Deck $deck;
+
     protected function setUp(): void
     {
         parent::setUp();
+        
         $this->seed('TarotCardsSeeder');
+        $this->createAuthenticatedUser();
+        $this->deck = Deck::where('user_id', $this->user->id)->first();
+        $this->assertNotNull($this->deck, "Deck was not created");
     }
 
-    /**
-     * Test that an authenticated user can get their deck.
-     *
-     * @return void
-     */
     public function test_user_can_get_their_deck(): void
-    {
-        // Arrange: Setup a user with a deck
-        $user = User::factory()->create();
+    {        
+
+        $response = $this->getJson('/api/decks', $this->authHeaders());
         
-        // User should have a deck created via the observer
-        $deck = Deck::where('user_id', $user->id)->first();
-        $this->assertNotNull($deck);
-        
-        // Act: Authenticate as user and make request
-        Passport::actingAs($user);
-        $response = $this->getJson('/api/decks');
-        
-        // Assert: Verify the response
         $response->assertStatus(200)
                  ->assertJsonStructure([
                      'data' => [
@@ -64,54 +53,32 @@ class GetUserDeckTest extends TestCase
                      ]
                  ]);
         
-        // Verify that the returned deck belongs to the user
-        $this->assertEquals($user->id, $response->json('data.user_id'));
+        $this->assertEquals($this->user->id, $response->json('data.user_id'));
         
-        // Verify that we have all 78 cards
         $this->assertCount(78, $response->json('data.cards'));
     }
 
-    /**
-     * Test that unauthenticated users cannot access the deck.
-     *
-     * @return void
-     */
     public function test_unauthenticated_user_cannot_get_deck(): void
     {
-        // Act: Make request without authentication
         $response = $this->getJson('/api/decks');
         
-        // Assert: Verify the response is unauthorized
         $response->assertStatus(401);
     }
 
-    /**
-     * Test that a user can only see their own deck.
-     *
-     * @return void
-     */
     public function test_user_can_only_see_own_deck(): void
     {
-        // Arrange: Setup two users with decks
-        $user1 = User::factory()->create();
-        $user2 = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $otherDeck = Deck::where('user_id', $otherUser->id)->first();
         
-        // Both users should have decks created via observer
-        $deck1 = Deck::where('user_id', $user1->id)->first();
-        $deck2 = Deck::where('user_id', $user2->id)->first();
+        $this->assertNotNull($this->deck);
+        $this->assertNotNull($otherDeck);
         
-        $this->assertNotNull($deck1);
-        $this->assertNotNull($deck2);
+        $response = $this->getJson('/api/decks', $this->authHeaders());
         
-        // Act: Authenticate as user1 and get deck
-        Passport::actingAs($user1);
-        $response = $this->getJson('/api/decks');
-        
-        // Assert: Verify that user1 can only see their own deck
         $response->assertStatus(200);
-        $this->assertEquals($user1->id, $response->json('data.user_id'));
-        $this->assertEquals($deck1->id, $response->json('data.id'));
-        $this->assertNotEquals($deck2->id, $response->json('data.id'));
+        $this->assertEquals($this->user->id, $response->json('data.user_id'));
+        $this->assertEquals($this->deck->id, $response->json('data.id'));
+        $this->assertNotEquals($otherDeck->id, $response->json('data.id'));
     }
 
 }

--- a/tests/Feature/API/Spread/SpreadCreationTest.php
+++ b/tests/Feature/API/Spread/SpreadCreationTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\API\ApiTestCase;
+use App\Models\Deck;
+use App\Models\User;
+
+class SpreadCreationTest extends ApiTestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+    protected Deck $deck;
+    protected string $token;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        $this->seed('TarotCardsSeeder');
+        $this->createAuthenticatedUser();
+        $this->deck = Deck::where('user_id', $this->user->id)->first();
+        $this->assertNotNull($this->deck, "Deck was not created");
+    }
+
+    public function test_unauthenticated_user_cannot_create_spread()
+    {        
+        $response = $this->postJson('/api/spreads', [
+            'spread_type' => 'first'
+        ]);
+        
+        $response->assertStatus(401);
+    }
+    
+    public function test_spread_type_is_required()
+    {
+        $response = $this->postJson('/api/spreads', [], $this->authHeaders());
+    
+        $response->assertStatus(422)
+                 ->assertJsonValidationErrors(['spread_type']);        
+
+    }
+    
+    public function test_spread_type_must_be_valid()
+    {
+        $response = $this->postJson('/api/spreads', [
+            'spread_type' => 'invalid_type'
+        ], $this->authHeaders());
+
+        $response->assertStatus(422)
+                 ->assertJsonValidationErrors(['spread_type']);
+    }
+    
+    public function test_user_can_create_single_card_spread()
+    {
+        $response = $this->postJson('/api/spreads', [
+            'spread_type' => 'first'
+        ], $this->authHeaders());
+        
+        $response->assertStatus(201)
+                 ->assertJsonStructure([
+                     'id',
+                     'deck_id',
+                     'spread_type',
+                     'creation_date',
+                     'cards' => [
+                         '*' => [
+                             'id',
+                             'position',
+                             'card' => [
+                                 'id',
+                                 'type',
+                                 'number',
+                                 'name',
+                                 'suit',
+                                 'element',
+                                 'meaning'
+                             ]
+                         ]
+                     ]
+                 ]);
+        
+        $responseData = $response->json();
+        $this->assertCount(1, $responseData['cards']);
+        
+        $this->assertDatabaseHas('spreads', [
+            'id' => $responseData['id'],
+            'deck_id' => $this->deck->id,
+            'spread_type' => 'first'
+        ]);
+    }
+    
+    public function test_user_can_create_three_card_spread()
+    {
+        $response = $this->postJson('/api/spreads', [
+            'spread_type' => 'second'
+        ], $this->authHeaders());
+        
+        $response->assertStatus(201)
+                 ->assertJsonStructure([
+                     'id',
+                     'deck_id',
+                     'spread_type',
+                     'creation_date',
+                     'cards' => [
+                         '*' => [
+                             'id',
+                             'position',
+                             'card' => [
+                                 'id',
+                                 'type',
+                                 'number',
+                                 'name',
+                                 'suit',
+                                 'element',
+                                 'meaning'
+                             ]
+                         ]
+                     ]
+                 ]);
+        
+        $responseData = $response->json();
+        $this->assertCount(3, $responseData['cards']);
+        
+        $this->assertDatabaseHas('spreads', [
+            'id' => $responseData['id'],
+            'deck_id' => $this->deck->id,
+            'spread_type' => 'second'
+        ]);
+    } 
+    
+}


### PR DESCRIPTION
This PR implements the spread creation endpoint following TDD principles.

Key changes:

- Create database migrations for spreads and spread_cards tables
- Implement Spread and SpreadCard models with proper relationships
- Develop TarotSpreadService for handling the business logic of tirada creation
- Add SpreadController with store method for creating new spreads
- Configure protected API route for POST /api/spreads
- Support both single card and three card spread types
- Return properly formatted JSON response with 201 status code

All tests pass successfully, and the endpoint can be tested with Postman.