### PR TITLE
Implement GET spread detail endpoint

### DIFF
--- a/app/Http/Controllers/API/SpreadController.php
+++ b/app/Http/Controllers/API/SpreadController.php
@@ -9,6 +9,8 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use App\Http\Resources\SpreadCollection;
 use App\Http\Resources\SpreadResource;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Auth\Access\AuthorizationException;
 
 class SpreadController extends Controller
 {
@@ -64,4 +66,28 @@ class SpreadController extends Controller
         }
     }
 
+    public function show($id)
+    {
+        try {
+            $spreadData = $this->spreadService->getSpread($id);
+            
+            return response()->json($spreadData);
+                
+        } catch (ModelNotFoundException $e) {
+            return response()->json([
+                'message' => 'Spread not found.'
+            ], 404);
+        } catch (AuthorizationException $e) {
+            return response()->json([
+                'message' => $e->getMessage()
+            ], 403);
+        } catch (\Exception $e) {
+            Log::error('Error fetching spread: ' . $e->getMessage());
+            
+            return response()->json([
+                'message' => 'Failed to fetch spread',
+                'error' => $e->getMessage()
+            ], 500);
+        }
+    }
 }

--- a/app/Services/SpreadService.php
+++ b/app/Services/SpreadService.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\DB;
 use App\Models\Spread;
 use App\Models\SpreadCard;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Auth\Access\AuthorizationException;
 
 class SpreadService
 {
@@ -74,6 +75,21 @@ class SpreadService
             'deck_id' => $deck->id,
             'spreads' => $spreads
         ];
+    }
+    
+    public function getSpread(int $spreadId): array
+    {
+        $deck = $this->deckService->getCurrentUserDeck();
+        
+        $spread = Spread::with('spreadCards.card')->findOrFail($spreadId);
+        
+        if ($spread->deck_id !== $deck->id) {
+            throw new AuthorizationException('You do not have permission to view this spread.');
+        }
+        
+        $cardsData = $spread->spreadCards->sortBy('position')->values()->map->toArray()->toArray();
+        
+        return $this->formatSpreadResponse($spread, $cardsData);
     }
     
     private function executeInTransaction(callable $callback)

--- a/routes/api.php
+++ b/routes/api.php
@@ -15,6 +15,7 @@ Route::middleware('auth:api')->group(function () {
     Route::put('/decks', [DeckController::class, 'update']);
     Route::get('/spreads', [SpreadController::class, 'index'])->name('spreads.index');
     Route::post('/spreads', [SpreadController::class, 'store'])->name('spreads.store');
+    Route::get('/spreads/{id}', [SpreadController::class, 'show'])->name('spreads.show');
 });
 
 Route::get('/test', function () {

--- a/tests/Feature/API/Deck/GetUserDeckTest.php
+++ b/tests/Feature/API/Deck/GetUserDeckTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Deck;
+namespace Tests\Feature\API\Deck;
 
 use App\Models\User;
 use App\Models\Deck;

--- a/tests/Feature/API/Spread/GetSpreadDetailTest.php
+++ b/tests/Feature/API/Spread/GetSpreadDetailTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Tests\Feature\API\Spread;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\API\ApiTestCase;
+use App\Models\Card;
+use App\Models\Deck;
+use App\Models\Spread;
+use App\Models\SpreadCard;
+use App\Models\User;
+
+class GetSpreadDetailTest extends ApiTestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+    protected User $anotherUser;
+    protected Deck $deck;
+    protected Spread $spread;
+    protected string $token;
+    protected string $anotherToken;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        $this->seed(['TarotCardsSeeder']);
+        
+        // Crear y autenticar el usuario principal
+        $this->createAuthenticatedUser();
+        $this->deck = Deck::where('user_id', $this->user->id)->first();
+        $this->assertNotNull($this->deck, "Deck was not created");
+        
+        // Crear otro usuario y autenticarlo
+        $this->anotherUser = User::factory()->create([
+            'name' => 'Another User',
+            'email' => 'another@example.com',
+            'birthdate' => '1990-01-01',
+            'password' => bcrypt('password'),
+        ]);
+        $this->anotherUser->assignRole('user');
+        
+        // Obtener token para el otro usuario
+        $loginResponse = $this->postJson('/api/tokens', [
+            'email' => $this->anotherUser->email,
+            'password' => 'password',
+        ]);
+        $this->anotherToken = $loginResponse->json('token');
+        
+        // Crear una tirada para el usuario principal
+        $this->spread = Spread::create([
+            'deck_id' => $this->deck->id,
+            'spread_type' => 'first',
+            'creation_date' => now()
+        ]);
+        
+        // Añadir una carta a la tirada
+        $card = Card::inRandomOrder()->first();
+        SpreadCard::create([
+            'spread_id' => $this->spread->id,
+            'card_id' => $card->id,
+            'position' => 1
+        ]);
+    }
+
+    public function test_unauthenticated_user_cannot_get_spread_detail()
+    {        
+        $response = $this->getJson("/api/spreads/{$this->spread->id}");
+        
+        $response->assertStatus(401);
+    }
+    
+    public function test_user_can_view_their_own_spread_with_cards()
+    {
+        $response = $this->getJson("/api/spreads/{$this->spread->id}", $this->authHeaders());
+        
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'id',
+                'deck_id',
+                'spread_type',
+                'creation_date',
+                'cards' => [
+                    '*' => [
+                        'id',
+                        'position',
+                        'card' => [
+                            'id',
+                            'type',
+                            'number',
+                            'name',
+                            'suit',
+                            'element',
+                            'meaning'
+                        ]
+                    ]
+                ]
+            ]);
+            
+        $data = $response->json();
+        $this->assertEquals($this->spread->id, $data['id']);
+        $this->assertEquals($this->deck->id, $data['deck_id']);
+        $this->assertEquals('first', $data['spread_type']);
+        $this->assertCount(1, $data['cards']);
+    }
+    
+    public function test_user_cannot_view_another_users_spread()
+    {
+        $anotherAuthHeaders = [
+            'Authorization' => 'Bearer ' . $this->anotherToken,
+            'Accept' => 'application/json',
+        ];
+        
+        $response = $this->getJson("/api/spreads/{$this->spread->id}", $anotherAuthHeaders);
+        
+        $response->assertStatus(403)
+            ->assertJson([
+                'message' => 'You do not have permission to view this spread.'
+            ]);
+    }
+    
+    public function test_returns_404_for_nonexistent_spread()
+    {
+        $nonexistentId = 9999;
+        
+        $response = $this->getJson("/api/spreads/{$nonexistentId}", $this->authHeaders());
+        
+        $response->assertStatus(404)
+            ->assertJson([
+                'message' => 'Spread not found.'
+            ]);
+    }
+}

--- a/tests/Feature/API/Spread/GetSpreadsTest.php
+++ b/tests/Feature/API/Spread/GetSpreadsTest.php
@@ -37,7 +37,6 @@ class GetSpreadsTest extends ApiTestCase
     
     public function test_user_can_get_list_of_spreads(): void
     {
-        // Crear algunas tiradas para este usuario
         $spread1 = Spread::create([
             'deck_id' => $this->deck->id,
             'spread_type' => 'first',
@@ -50,17 +49,14 @@ class GetSpreadsTest extends ApiTestCase
             'creation_date' => now()
         ]);
         
-        // Añadir cartas a las tiradas
         $cards = Card::inRandomOrder()->take(4)->get();
         
-        // Para la primera tirada (una carta)
         SpreadCard::create([
             'spread_id' => $spread1->id,
             'card_id' => $cards[0]->id,
             'position' => 1
         ]);
         
-        // Para la segunda tirada (tres cartas)
         for ($i = 0; $i < 3; $i++) {
             SpreadCard::create([
                 'spread_id' => $spread2->id,
@@ -94,7 +90,6 @@ class GetSpreadsTest extends ApiTestCase
 
     public function test_user_can_filter_spreads_by_type(): void
     {
-        // Crear tiradas de diferentes tipos
         Spread::create([
             'deck_id' => $this->deck->id,
             'spread_type' => 'first',
@@ -107,7 +102,6 @@ class GetSpreadsTest extends ApiTestCase
             'creation_date' => now()
         ]);
         
-        // Filtrar por tipo 'first'
         $response = $this->getJson('/api/spreads?spread_type=first', $this->authHeaders());
         
         $response->assertStatus(200);
@@ -118,9 +112,7 @@ class GetSpreadsTest extends ApiTestCase
     }
 
     public function test_returns_empty_array_when_no_spreads(): void
-    {
-        // No crear ninguna tirada
-        
+    {        
         $response = $this->getJson('/api/spreads', $this->authHeaders());
         
         $response->assertStatus(200);

--- a/tests/Feature/API/Spread/SpreadCreationTest.php
+++ b/tests/Feature/API/Spread/SpreadCreationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\API\Spreads;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Feature\API\ApiTestCase;


### PR DESCRIPTION
This PR implements the spread detail endpoint following TDD principles.

Key changes:

- Create tests to verify access to individual spreads with proper authentication
- Implement authorization checks to ensure users can only view their own spreads
- Add method in SpreadService to retrieve spread details with associated cards
- Implement controller method with comprehensive error handling
- Set up protected GET /api/spreads/{id} endpoint
- Verify functionality works correctly in Postman

All tests pass successfully, and the endpoint can be tested with Postman to retrieve spread details including associated cards.