### PR TITLE
Implement delete spread endpoint

### DIFF
--- a/app/Http/Controllers/API/SpreadController.php
+++ b/app/Http/Controllers/API/SpreadController.php
@@ -90,4 +90,29 @@ class SpreadController extends Controller
             ], 500);
         }
     }
+
+    public function destroy($id)
+    {
+        try {
+            $this->spreadService->deleteSpread($id);
+            
+            return response()->json(null, 204);
+                
+        } catch (ModelNotFoundException $e) {
+            return response()->json([
+                'message' => 'Spread not found.'
+            ], 404);
+        } catch (AuthorizationException $e) {
+            return response()->json([
+                'message' => $e->getMessage()
+            ], 403);
+        } catch (\Exception $e) {
+            Log::error('Error deleting spread: ' . $e->getMessage());
+            
+            return response()->json([
+                'message' => 'Failed to delete spread',
+                'error' => $e->getMessage()
+            ], 500);
+        }
+    }
 }

--- a/app/Services/SpreadService.php
+++ b/app/Services/SpreadService.php
@@ -91,6 +91,21 @@ class SpreadService
         
         return $this->formatSpreadResponse($spread, $cardsData);
     }
+
+    public function deleteSpread(int $spreadId): bool
+    {
+        $deck = $this->deckService->getCurrentUserDeck();
+        
+        $spread = Spread::findOrFail($spreadId);
+        
+        if ($spread->deck_id !== $deck->id) {
+            throw new AuthorizationException('You do not have permission to delete this spread.');
+        }
+        return $this->executeInTransaction(function() use ($spread) {
+            
+            return $spread->delete();
+        });
+    }
     
     private function executeInTransaction(callable $callback)
     {

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,11 +11,14 @@ Route::middleware('auth:api')->group(function () {
     Route::get('/users/{id?}', [UserController::class, 'show'])->name('users.show');
     Route::put('/users/{id?}', [UserController::class, 'update'])->name('users.update');
     Route::delete('/users', [UserController::class, 'destroy'])->name('users.destroy');
+    
     Route::get('/decks', [DeckController::class, 'index'])->name('decks.index');
-    Route::put('/decks', [DeckController::class, 'update']);
+    Route::put('/decks', [DeckController::class, 'update'])->name('decks.update');
+    
     Route::get('/spreads', [SpreadController::class, 'index'])->name('spreads.index');
     Route::post('/spreads', [SpreadController::class, 'store'])->name('spreads.store');
     Route::get('/spreads/{id}', [SpreadController::class, 'show'])->name('spreads.show');
+    Route::delete('/spreads/{id}', [SpreadController::class, 'destroy'])->name('spreads.destroy');
 });
 
 Route::get('/test', function () {

--- a/tests/Feature/API/Spread/DeleteSpreadTest.php
+++ b/tests/Feature/API/Spread/DeleteSpreadTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Tests\Feature\API\Spread;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\API\ApiTestCase;
+use App\Models\Card;
+use App\Models\Deck;
+use App\Models\Spread;
+use App\Models\SpreadCard;
+use App\Models\User;
+
+class DeleteSpreadTest extends ApiTestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+    protected User $anotherUser;
+    protected Deck $deck;
+    protected Spread $spread;
+    protected string $token;
+    protected string $anotherToken;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        $this->seed(['TarotCardsSeeder']);
+        
+        // Crear y autenticar el usuario principal
+        $this->createAuthenticatedUser();
+        $this->deck = Deck::where('user_id', $this->user->id)->first();
+        $this->assertNotNull($this->deck, "Deck was not created");
+        
+        // Crear otro usuario y autenticarlo
+        $this->anotherUser = User::factory()->create([
+            'name' => 'Another User',
+            'email' => 'another@example.com',
+            'birthdate' => '1990-01-01',
+            'password' => bcrypt('password'),
+        ]);
+        $this->anotherUser->assignRole('user');
+        
+        // Obtener token para el otro usuario
+        $loginResponse = $this->postJson('/api/tokens', [
+            'email' => $this->anotherUser->email,
+            'password' => 'password',
+        ]);
+        $this->anotherToken = $loginResponse->json('token');
+        
+        // Crear una tirada para el usuario principal
+        $this->spread = Spread::create([
+            'deck_id' => $this->deck->id,
+            'spread_type' => 'first',
+            'creation_date' => now()
+        ]);
+        
+        // Añadir una carta a la tirada
+        $card = Card::inRandomOrder()->first();
+        SpreadCard::create([
+            'spread_id' => $this->spread->id,
+            'card_id' => $card->id,
+            'position' => 1
+        ]);
+    }
+
+    public function test_unauthenticated_user_cannot_delete_spread()
+    {        
+        $response = $this->deleteJson("/api/spreads/{$this->spread->id}");
+        
+        $response->assertStatus(401);
+    }
+    
+    public function test_user_can_delete_their_own_spread()
+    {
+        $response = $this->deleteJson("/api/spreads/{$this->spread->id}", [], $this->authHeaders());
+        
+        $response->assertStatus(204);
+        
+        // Verificar que la tirada ya no existe en la base de datos
+        $this->assertDatabaseMissing('spreads', [
+            'id' => $this->spread->id
+        ]);
+        
+        // Verificar que las cartas asociadas también se eliminaron
+        $this->assertDatabaseMissing('spread_cards', [
+            'spread_id' => $this->spread->id
+        ]);
+    }
+    
+    public function test_user_cannot_delete_another_users_spread()
+    {
+        $anotherAuthHeaders = [
+            'Authorization' => 'Bearer ' . $this->anotherToken,
+            'Accept' => 'application/json',
+        ];
+        
+        $response = $this->deleteJson("/api/spreads/{$this->spread->id}", [], $anotherAuthHeaders);
+        
+        $response->assertStatus(403)
+            ->assertJson([
+                'message' => 'You do not have permission to delete this spread.'
+            ]);
+            
+        // Verificar que la tirada sigue existiendo
+        $this->assertDatabaseHas('spreads', [
+            'id' => $this->spread->id
+        ]);
+    }
+    
+    public function test_returns_404_for_nonexistent_spread()
+    {
+        $nonexistentId = 9999;
+        
+        $response = $this->deleteJson("/api/spreads/{$nonexistentId}", [], $this->authHeaders());
+        
+        $response->assertStatus(404)
+            ->assertJson([
+                'message' => 'Spread not found.'
+            ]);
+    }
+}


### PR DESCRIPTION
This PR implements the spread deletion endpoint following TDD principles.

Key changes:

- Create DeleteSpreadTest with test cases including authorization checks
- Implement SpreadService.deleteSpread method that validates user ownership of the spread
- Add SpreadController.destroy method with proper error handling for various scenarios
- Set up protected DELETE /api/spreads/{id} endpoint with authentication
- Use database transactions to maintain data integrity
- Handle 404 error cases for non-existent spreads

All tests pass successfully, and the end point can be test with postman. 