### PR TITLE
 Role-Based Spreads Management Implementation

### DIFF
--- a/app/Http/Controllers/API/SpreadController.php
+++ b/app/Http/Controllers/API/SpreadController.php
@@ -4,9 +4,11 @@ namespace App\Http\Controllers\API;
 
 use App\Http\Controllers\Controller;
 use App\Models\Spread;
-use App\Services\{DeckService, SpreadService};
+use App\Services\DeckService;
+use App\Services\SpreadService;
+use App\Services\RoleService;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\{Auth, Log};
 use App\Http\Resources\SpreadCollection;
 use App\Http\Resources\SpreadResource;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -16,40 +18,34 @@ class SpreadController extends Controller
 {
     protected $spreadService;
     protected $deckService;
+    protected $roleService;
     
-    public function __construct(SpreadService $spreadService, DeckService $deckService)
-    {
+    public function __construct(
+        SpreadService $spreadService, 
+        DeckService $deckService,
+        RoleService $roleService
+    ) {
         $this->spreadService = $spreadService;
         $this->deckService = $deckService;
-    }
-
-    public function store(Request $request)
-    {
-        $validated = $request->validate([
-            'spread_type' => 'required|in:' . implode(',', Spread::TYPES),
-        ]);
-        
-        try {
-            $spreadData = $this->spreadService->createSpread($validated['spread_type']);
-            
-            Log::info('Spread created with ID: ' . $spreadData['id']);
-            
-            return response()->json($spreadData, 201);
-                
-        } catch (\Exception $e) {
-            Log::error('Error creating spread: ' . $e->getMessage());
-            
-            return response()->json([
-                'message' => 'Failed to create spread',
-                'error' => $e->getMessage()
-            ], 500);
-        }
+        $this->roleService = $roleService;
     }
 
     public function index(Request $request)
     {
         try {
+            $user = Auth::user();
             $spreadType = $request->input('spread_type');
+            
+            if ($this->roleService->canViewAllSpreads($user)) {
+                $spreads = Spread::when($spreadType, function($query) use ($spreadType) {
+                    return $query->where('spread_type', $spreadType);
+                })->orderBy('creation_date', 'desc')->get();
+                
+                return response()->json([
+                    'spreads' => $spreads->toArray()
+                ]);
+            }
+            
             $data = $this->spreadService->getSpreadsForDeck($spreadType);
             
             return new SpreadCollection(
@@ -69,18 +65,34 @@ class SpreadController extends Controller
     public function show($id)
     {
         try {
-            $spreadData = $this->spreadService->getSpread($id);
+            $user = Auth::user();
+            $spread = Spread::findOrFail($id);
             
-            return response()->json($spreadData);
+            if (!$this->roleService->canViewSpread($user, $spread)) {
+                return response()->json([
+                    'message' => 'You do not have permission to view this spread.'
+                ], 403);
+            }
+            
+            try {
+                $spreadData = $this->spreadService->getSpread($id);
+                return response()->json($spreadData);
+            } catch (AuthorizationException $e) {
+                $spread->load('spreadCards.card');
+                $cardsData = $spread->spreadCards->sortBy('position')->values()->map->toArray()->toArray();
                 
+                return response()->json([
+                    'id' => $spread->id,
+                    'deck_id' => $spread->deck_id,
+                    'spread_type' => $spread->spread_type,
+                    'creation_date' => $spread->creation_date->format('Y-m-d H:i:s'),
+                    'cards' => $cardsData
+                ]);
+            }
         } catch (ModelNotFoundException $e) {
             return response()->json([
                 'message' => 'Spread not found.'
             ], 404);
-        } catch (AuthorizationException $e) {
-            return response()->json([
-                'message' => $e->getMessage()
-            ], 403);
         } catch (\Exception $e) {
             Log::error('Error fetching spread: ' . $e->getMessage());
             
@@ -94,23 +106,53 @@ class SpreadController extends Controller
     public function destroy($id)
     {
         try {
-            $this->spreadService->deleteSpread($id);
+            $user = Auth::user();
+            $spread = Spread::findOrFail($id);
+            
+            if (!$this->roleService->canDeleteSpread($user, $spread)) {
+                return response()->json([
+                    'message' => 'You do not have permission to delete this spread.'
+                ], 403);
+            }
+            
+            try {
+                $this->spreadService->deleteSpread($id);
+            } catch (AuthorizationException $e) {
+                $spread->delete();
+            }
             
             return response()->json(null, 204);
-                
         } catch (ModelNotFoundException $e) {
             return response()->json([
                 'message' => 'Spread not found.'
             ], 404);
-        } catch (AuthorizationException $e) {
-            return response()->json([
-                'message' => $e->getMessage()
-            ], 403);
         } catch (\Exception $e) {
             Log::error('Error deleting spread: ' . $e->getMessage());
             
             return response()->json([
                 'message' => 'Failed to delete spread',
+                'error' => $e->getMessage()
+            ], 500);
+        }
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'spread_type' => 'required|in:' . implode(',', Spread::TYPES),
+        ]);
+        
+        try {
+            $spreadData = $this->spreadService->createSpread($validated['spread_type']);
+            
+            Log::info('Spread created with ID: ' . $spreadData['id']);
+            
+            return response()->json($spreadData, 201);
+        } catch (\Exception $e) {
+            Log::error('Error creating spread: ' . $e->getMessage());
+            
+            return response()->json([
+                'message' => 'Failed to create spread',
                 'error' => $e->getMessage()
             ], 500);
         }

--- a/app/Services/RoleService.php
+++ b/app/Services/RoleService.php
@@ -3,38 +3,44 @@
 namespace App\Services;
 
 use App\Models\User;
+use App\Models\Spread;
 
 class RoleService
 {
-    /**
-     * Determina si un usuario puede ver la lista de todos los usuarios
-     */
+
     public function canViewAllUsers(User $user): bool
     {
         return $user->hasRole('admin');
     }
-    
-    /**
-     * Determina si un usuario puede ver el perfil de otro usuario
-     */
+
     public function canViewUserProfile(User $currentUser, int $targetUserId): bool
     {
         return $currentUser->id == $targetUserId || $currentUser->hasRole('admin');
     }
     
-    /**
-     * Determina si un usuario puede actualizar el perfil de otro usuario
-     */
     public function canUpdateUserProfile(User $currentUser, int $targetUserId): bool
     {
         return $currentUser->id == $targetUserId || $currentUser->hasRole('admin');
     }
     
-    /**
-     * Determina si un usuario puede eliminar a otro usuario
-     */
     public function canDeleteUser(User $currentUser, int $targetUserId): bool
     {
         return $currentUser->id == $targetUserId || $currentUser->hasRole('admin');
+    }
+
+        public function canViewAllSpreads(User $user): bool
+    {
+        return $user->hasRole('admin');
+    }
+
+    public function canViewSpread(User $user, Spread $spread): bool
+    {
+        return $user->hasRole('admin') || 
+            ($user->deck && $spread->deck_id === $user->deck->id);
+    }
+
+    public function canDeleteSpread(User $user, Spread $spread): bool
+    {
+        return $this->canViewSpread($user, $spread);
     }
 }

--- a/tests/Feature/API/Roles/RolePermissionTest.php
+++ b/tests/Feature/API/Roles/RolePermissionTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature\API;
 
 use App\Models\User;
 use Spatie\Permission\Models\Role;
-use Spatie\Permission\Models\Permission;
 
 class RolePermissionTest extends ApiTestCase
 {

--- a/tests/Feature/API/Roles/SpreadManagementTest.php
+++ b/tests/Feature/API/Roles/SpreadManagementTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Tests\Feature\API\Spread;
+
+use App\Models\User;
+use App\Models\Spread;
+use Tests\Feature\API\ApiTestCase;
+
+class SpreadManagementTest extends ApiTestCase
+{
+    protected User $adminUser;
+    protected string $adminToken;
+    protected Spread $userSpread;
+    protected Spread $adminSpread;
+    protected Spread $otherUserSpread;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        $this->createAuthenticatedUser();
+        
+        $this->adminUser = User::factory()->create([
+            'name' => 'Admin User',
+            'email' => 'admin@example.com',
+            'birthdate' => '1990-01-01',
+            'password' => bcrypt('password'),
+        ]);
+        $this->adminUser->assignRole('admin');
+        
+        $adminLoginResponse = $this->postJson('/api/tokens', [
+            'email' => 'admin@example.com',
+            'password' => 'password',
+        ]);
+        $this->adminToken = $adminLoginResponse->json('token');
+        
+        $otherUser = User::factory()->create([
+            'name' => 'Other User',
+            'email' => 'other@example.com',
+            'birthdate' => '1995-01-01',
+            'password' => bcrypt('password'),
+        ]);
+        $otherUser->assignRole('user');
+        
+        $userDeck = $this->user->deck;
+        $this->userSpread = Spread::create([
+            'deck_id' => $userDeck->id,
+            'spread_type' => 'first',
+            'creation_date' => now(),
+        ]);
+        
+        $adminDeck = $this->adminUser->deck;
+        $this->adminSpread = Spread::create([
+            'deck_id' => $adminDeck->id,
+            'spread_type' => 'second',
+            'creation_date' => now(),
+        ]);
+        
+        $otherUserDeck = $otherUser->deck;
+        $this->otherUserSpread = Spread::create([
+            'deck_id' => $otherUserDeck->id,
+            'spread_type' => 'first',
+            'creation_date' => now(),
+        ]);
+    }
+
+    protected function adminHeaders(): array
+    {
+        return [
+            'Authorization' => 'Bearer ' . $this->adminToken,
+            'Accept' => 'application/json',
+        ];
+    }
+
+    public function test_admin_can_view_all_spreads()
+    {
+        $response = $this->getJson('/api/spreads', $this->adminHeaders());
+        
+        $response->assertStatus(200);
+        
+        // La respuesta para admin viene en formato 'spreads'
+        $spreads = $response->json('spreads');
+        
+        // Verificar que se muestran las 3 tiradas
+        $this->assertCount(3, $spreads);
+        
+        // Verificar que las tiradas incluyen las de todos los usuarios
+        $ids = array_column($spreads, 'id');
+        $this->assertContains($this->userSpread->id, $ids);
+        $this->assertContains($this->adminSpread->id, $ids);
+        $this->assertContains($this->otherUserSpread->id, $ids);
+    }
+
+    public function test_normal_user_can_only_view_own_spreads()
+    {
+        $response = $this->getJson('/api/spreads', $this->authHeaders());
+        
+        $response->assertStatus(200);
+        
+        // Verificar que la respuesta tiene el formato esperado
+        $this->assertArrayHasKey('data', $response->json());
+        $data = $response->json('data');
+        
+        // Verificar que hay spreads dentro de data
+        $this->assertArrayHasKey('spreads', $data);
+        $spreads = $data['spreads'];
+        
+        // Verificar que solo se muestra 1 tirada (la del usuario)
+        $this->assertCount(1, $spreads);
+        
+        // Verificar que la tirada es del usuario actual y no de otros
+        $ids = array_column($spreads, 'id');
+        $this->assertContains($this->userSpread->id, $ids);
+        $this->assertNotContains($this->otherUserSpread->id, $ids);
+    }
+
+    public function test_admin_can_view_any_spread_details()
+    {
+        $response = $this->getJson("/api/spreads/{$this->adminSpread->id}", $this->adminHeaders());
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['id' => $this->adminSpread->id]);
+        
+        $response = $this->getJson("/api/spreads/{$this->userSpread->id}", $this->adminHeaders());
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['id' => $this->userSpread->id]);
+    }
+
+    public function test_normal_user_can_only_view_own_spread_details()
+    {
+        $response = $this->getJson("/api/spreads/{$this->userSpread->id}", $this->authHeaders());
+        $response->assertStatus(200);
+        $response->assertJsonFragment(['id' => $this->userSpread->id]);
+        
+        $response = $this->getJson("/api/spreads/{$this->otherUserSpread->id}", $this->authHeaders());
+        $response->assertStatus(403);
+    }
+
+    public function test_admin_can_delete_any_spread()
+    {
+        // Corrección: Los headers deben ir como tercer parámetro
+        $response = $this->deleteJson("/api/spreads/{$this->userSpread->id}", [], $this->adminHeaders());
+        $response->assertStatus(204);
+        
+        $this->assertDatabaseMissing('spreads', ['id' => $this->userSpread->id]);
+    }
+
+    public function test_normal_user_can_only_delete_own_spread()
+    {
+        $userDeck = $this->user->deck;
+        $secondUserSpread = Spread::create([
+            'deck_id' => $userDeck->id,
+            'spread_type' => 'first',
+            'creation_date' => now(),
+        ]);
+        
+        // Corrección: Los headers deben ir como tercer parámetro
+        $response = $this->deleteJson("/api/spreads/{$this->otherUserSpread->id}", [], $this->authHeaders());
+        $response->assertStatus(403);
+        
+        $this->assertDatabaseHas('spreads', ['id' => $this->otherUserSpread->id]);
+        
+        // Corrección: Los headers deben ir como tercer parámetro
+        $response = $this->deleteJson("/api/spreads/{$secondUserSpread->id}", [], $this->authHeaders());
+        $response->assertStatus(204);
+        
+        $this->assertDatabaseMissing('spreads', ['id' => $secondUserSpread->id]);
+    }
+
+    public function test_unauthorized_user_cannot_access_spreads()
+    {
+        $this->assertUnauthorizedAccess('/api/spreads');
+        $this->assertUnauthorizedAccess("/api/spreads/{$this->userSpread->id}");
+        $this->assertUnauthorizedAccess("/api/spreads/{$this->userSpread->id}", 'DELETE');
+    }
+}

--- a/tests/Feature/API/Roles/UserManagementTest.php
+++ b/tests/Feature/API/Roles/UserManagementTest.php
@@ -9,14 +9,12 @@ class UserManagementTest extends ApiTestCase
 {
     public function test_admin_can_view_all_users()
     {
-        // Crear algunos usuarios adicionales en la base de datos
         $user1 = User::factory()->create(['email' => 'user1@example.com']);
         $user1->assignRole('user');
         
         $user2 = User::factory()->create(['email' => 'user2@example.com']);
         $user2->assignRole('user');
         
-        // Crear un admin y obtener su token
         $admin = User::factory()->create([
             'name' => 'Admin User',
             'email' => 'admin@example.com',
@@ -32,13 +30,11 @@ class UserManagementTest extends ApiTestCase
         
         $adminToken = $adminLoginResponse->json('token');
         
-        // Solicitar la lista de usuarios como administrador
         $response = $this->withHeaders([
             'Authorization' => 'Bearer ' . $adminToken,
             'Accept' => 'application/json',
         ])->getJson('/api/users');
         
-        // Verificar que la respuesta contiene la lista de todos los usuarios
         $response->assertStatus(200);
         $this->assertCount(3, $response->json('data'));
         $response->assertJsonFragment(['email' => 'user1@example.com']);
@@ -48,24 +44,18 @@ class UserManagementTest extends ApiTestCase
 
     public function test_normal_user_cannot_view_all_users()
     {
-        // Crear y autenticar un usuario normal
         $this->createAuthenticatedUser();
         
-        // Crear otro usuario
         $anotherUser = User::factory()->create(['email' => 'another@example.com']);
         $anotherUser->assignRole('user');
         
-        // Intentar acceder al endpoint /users como usuario normal
         $response = $this->withHeaders($this->authHeaders())
             ->getJson('/api/users');
         
-        // Verificar que solo ve su propio perfil, no una lista de usuarios
         $response->assertStatus(200);
         $response->assertJsonFragment(['email' => $this->user->email]);
         $response->assertJsonMissing(['email' => 'another@example.com']);
         
-        // Confirmar que solo hay 1 usuario en la respuesta (su propio perfil)
-        // La respuesta podría venir como un objeto único o dentro de un array 'data'
         if (isset($response->json()['data'])) {
             $this->assertCount(1, $response->json('data'));
         } else {
@@ -75,11 +65,9 @@ class UserManagementTest extends ApiTestCase
 
     public function test_admin_can_view_specific_user_profile()
     {
-        // Crear un usuario normal
         $regularUser = User::factory()->create(['email' => 'regular@example.com']);
         $regularUser->assignRole('user');
         
-        // Crear y autenticar un administrador
         $admin = User::factory()->create([
             'name' => 'Admin User',
             'email' => 'admin@example.com',
@@ -95,55 +83,44 @@ class UserManagementTest extends ApiTestCase
         
         $adminToken = $adminLoginResponse->json('token');
         
-        // Solicitar el perfil del usuario normal como administrador
         $response = $this->withHeaders([
             'Authorization' => 'Bearer ' . $adminToken,
             'Accept' => 'application/json',
         ])->getJson('/api/users/' . $regularUser->id);
         
-        // Verificar que puede ver el perfil del usuario
         $response->assertStatus(200);
         $response->assertJsonFragment(['email' => 'regular@example.com']);
     }
 
     public function test_normal_user_cannot_view_other_user_profile()
     {
-        // Crear y autenticar un usuario normal
         $this->createAuthenticatedUser();
         
-        // Crear otro usuario normal
         $anotherUser = User::factory()->create(['email' => 'another@example.com']);
         $anotherUser->assignRole('user');
         
-        // Intentar acceder al perfil del otro usuario
         $response = $this->withHeaders($this->authHeaders())
             ->getJson('/api/users/' . $anotherUser->id);
         
-        // Verificar que no puede ver el perfil de otro usuario
         $response->assertStatus(403);
     }
 
     public function test_normal_user_can_view_own_profile()
     {
-        // Crear y autenticar un usuario normal
         $this->createAuthenticatedUser();
         
-        // Acceder a su propio perfil
         $response = $this->withHeaders($this->authHeaders())
             ->getJson('/api/users/' . $this->user->id);
         
-        // Verificar que puede ver su propio perfil
         $response->assertStatus(200);
         $response->assertJsonFragment(['email' => $this->user->email]);
     }
     
         public function test_admin_can_see_user_roles()
     {
-        // Crear usuarios con diferentes roles
         $regularUser = User::factory()->create(['email' => 'regular@example.com']);
         $regularUser->assignRole('user');
         
-        // Crear y autenticar un administrador
         $admin = User::factory()->create([
             'name' => 'Admin User',
             'email' => 'admin@example.com',
@@ -159,23 +136,18 @@ class UserManagementTest extends ApiTestCase
         
         $adminToken = $adminLoginResponse->json('token');
         
-        // Primero, obtener el perfil específico del usuario regular como admin
         $response = $this->withHeaders([
             'Authorization' => 'Bearer ' . $adminToken,
             'Accept' => 'application/json',
         ])->getJson('/api/users/' . $regularUser->id);
         
-        // Verificar que la respuesta incluye información sobre roles
         $response->assertStatus(200);
         $userData = $response->json('data');
         
-        // Verificar que el campo 'roles' existe en la respuesta
         $this->assertArrayHasKey('roles', $userData);
         
-        // Verificar que el usuario normal tiene el rol 'user'
         $this->assertContains('user', $userData['roles']);
         
-        // Obtener perfil propio del admin
         $response = $this->withHeaders([
             'Authorization' => 'Bearer ' . $adminToken,
             'Accept' => 'application/json',
@@ -183,17 +155,12 @@ class UserManagementTest extends ApiTestCase
         
         $adminData = $response->json('data');
         
-        // Verificar que el admin tiene el rol 'admin'
         $this->assertArrayHasKey('roles', $adminData);
         $this->assertContains('admin', $adminData['roles']);
     }
 
-        /**
-     * Test admin can update any user profile
-     */
     public function test_admin_can_update_any_user_profile(): void
     {
-        // Crear un usuario normal
         $regularUser = User::factory()->create([
             'name' => 'Regular User',
             'email' => 'regular@example.com',
@@ -201,7 +168,6 @@ class UserManagementTest extends ApiTestCase
         ]);
         $regularUser->assignRole('user');
         
-        // Crear y autenticar un admin
         $admin = User::factory()->create([
             'name' => 'Admin User',
             'email' => 'admin@example.com',
@@ -217,13 +183,11 @@ class UserManagementTest extends ApiTestCase
         
         $adminToken = $loginResponse->json('token');
         
-        // Datos de actualización
         $updateData = [
             'name' => 'Updated By Admin',
             'email' => 'updated-by-admin@example.com',
         ];
         
-        // Admin intenta actualizar el perfil del usuario normal
         $response = $this->withHeaders([
             'Authorization' => 'Bearer ' . $adminToken,
             'Accept' => 'application/json',
@@ -231,7 +195,6 @@ class UserManagementTest extends ApiTestCase
         
         $response->assertStatus(200);
         
-        // Verificar que los datos se actualizaron
         $this->assertDatabaseHas('users', [
             'id' => $regularUser->id,
             'name' => 'Updated By Admin',
@@ -239,15 +202,10 @@ class UserManagementTest extends ApiTestCase
         ]);
     }
     
-    /**
-     * Test user cannot update another user's profile
-     */
     public function test_user_cannot_update_another_user_profile(): void
     {
-        // Crear y autenticar un usuario normal
         $this->createAuthenticatedUser();
         
-        // Crear otro usuario
         $anotherUser = User::factory()->create([
             'name' => 'Another User',
             'email' => 'another@example.com',
@@ -255,59 +213,44 @@ class UserManagementTest extends ApiTestCase
         ]);
         $anotherUser->assignRole('user');
         
-        // Datos de actualización
         $updateData = [
             'name' => 'Tried To Update',
         ];
         
-        // Intentar actualizar el otro usuario
         $response = $this->withHeaders($this->authHeaders())
             ->putJson('/api/users/' . $anotherUser->id, $updateData);
         
-        // Debe recibir un error de permiso
         $response->assertStatus(403);
         
-        // Verificar que los datos NO se actualizaron
         $this->assertDatabaseMissing('users', [
             'id' => $anotherUser->id,
             'name' => 'Tried To Update',
         ]);
     }
-    
-    /**
-     * Test user can update own profile
-     */
+
     public function test_user_can_update_own_profile(): void
     {
-        // Crear y autenticar un usuario normal
         $this->createAuthenticatedUser();
         
-        // Datos de actualización
         $updateData = [
             'name' => 'Self Updated',
             'email' => 'self-updated@example.com',
         ];
         
-        // Actualizar su propio perfil
         $response = $this->withHeaders($this->authHeaders())
             ->putJson('/api/users/' . $this->user->id, $updateData);
         
         $response->assertStatus(200);
         
-        // Verificar que los datos se actualizaron
         $this->assertDatabaseHas('users', [
             'id' => $this->user->id,
             'name' => 'Self Updated',
             'email' => 'self-updated@example.com',
         ]);
     }
-    
-    /**
-     * Test admin can delete any user
-     */
+
     public function test_admin_can_delete_any_user(): void
     {
-        // Crear un usuario normal
         $regularUser = User::factory()->create([
             'name' => 'User To Delete',
             'email' => 'delete-me@example.com',
@@ -316,7 +259,6 @@ class UserManagementTest extends ApiTestCase
         $regularUser->assignRole('user');
         $regularUserId = $regularUser->id;
         
-        // Crear y autenticar un admin
         $admin = User::factory()->create([
             'name' => 'Admin User',
             'email' => 'admin@example.com',
@@ -332,7 +274,6 @@ class UserManagementTest extends ApiTestCase
         
         $adminToken = $loginResponse->json('token');
         
-        // Admin intenta eliminar al usuario normal
         $response = $this->withHeaders([
             'Authorization' => 'Bearer ' . $adminToken,
             'Accept' => 'application/json',
@@ -340,21 +281,15 @@ class UserManagementTest extends ApiTestCase
         
         $response->assertStatus(204);
         
-        // Verificar que el usuario fue eliminado
         $this->assertDatabaseMissing('users', [
             'id' => $regularUserId,
         ]);
     }
     
-    /**
-     * Test user cannot delete another user
-     */
     public function test_user_cannot_delete_another_user(): void
     {
-        // Crear y autenticar un usuario normal
         $this->createAuthenticatedUser();
         
-        // Crear otro usuario
         $anotherUser = User::factory()->create([
             'name' => 'Another User',
             'email' => 'another@example.com',
@@ -363,35 +298,26 @@ class UserManagementTest extends ApiTestCase
         $anotherUser->assignRole('user');
         $anotherUserId = $anotherUser->id;
         
-        // Intentar eliminar al otro usuario
         $response = $this->withHeaders($this->authHeaders())
             ->deleteJson('/api/users/' . $anotherUserId);
         
-        // Debe recibir un error de permiso
         $response->assertStatus(403);
         
-        // Verificar que el usuario NO fue eliminado
         $this->assertDatabaseHas('users', [
             'id' => $anotherUserId,
         ]);
     }
     
-    /**
-     * Test user can delete own account
-     */
     public function test_user_can_delete_own_account(): void
     {
-        // Crear y autenticar un usuario normal
         $this->createAuthenticatedUser();
         $userId = $this->user->id;
         
-        // Eliminar su propia cuenta
         $response = $this->withHeaders($this->authHeaders())
             ->deleteJson('/api/users/' . $userId);
         
         $response->assertStatus(204);
         
-        // Verificar que el usuario fue eliminado
         $this->assertDatabaseMissing('users', [
             'id' => $userId,
         ]);


### PR DESCRIPTION
This PR implements role-based access control for spread management following a Test-Driven Development approach.

## Key Changes:

- Created tests to verify that:
  - Admin users can view all spreads across the system
  - Admin users can view and delete any individual spread
  - Normal users can only view and manage their own spreads
  - Unauthorized access is properly rejected

- Extended the RoleService to handle spread-specific permissions
  - Added methods to check if a user can view/manage all spreads
  - Added methods to verify if a user can access a specific spread

- Modified SpreadController to use role-based authorization
  - Updated index method to show all spreads for admins
  - Added permission checks before showing or deleting spreads
  - Maintained compatibility with existing response formats

All tests are now passing.